### PR TITLE
Fix palier ordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,19 +119,21 @@
       const { data: paliers } = await supabase
         .from("paliers")
         .select("*")
-        .eq("id_liste", currentListe);
+        .eq("id_liste", currentListe)
+        .order("ordre", { ascending: true });
 
       paliersMap = Object.fromEntries(paliers.map(p => [p.id, p.nom]));
+      const orderedPalierIds = paliers.map(p => p.id);
 
       const { data: taches } = await supabase
         .from("taches")
         .select("*")
         .eq("id_liste", currentListe);
 
-      afficherTaches(taches);
+      afficherTaches(taches, orderedPalierIds);
     }
 
-    function afficherTaches(taches) {
+    function afficherTaches(taches, orderedPalierIds) {
       const container = document.getElementById("objectifs");
       container.innerHTML = "";
       const grouped = {};
@@ -141,7 +143,9 @@
         grouped[t.id_palier].push(t);
       });
 
-      Object.entries(grouped).forEach(([palierId, taches]) => {
+      orderedPalierIds.forEach(palierId => {
+        const taches = grouped[palierId];
+        if (!taches) return;
         const div = document.createElement("div");
         div.className = "tier";
 


### PR DESCRIPTION
## Summary
- sort paliers by their `ordre` column when loading tasks
- render each palier in the sorted order

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b9e8c694c8327910d8b0b75ad8578