### PR TITLE
Centralize Supabase client

### DIFF
--- a/create_liste.html
+++ b/create_liste.html
@@ -53,11 +53,8 @@
     <p id="status"></p>
   </div>
 
-  <script>
-    const supabase = window.supabase.createClient(
-      "https://glercnffjbmetbystnwi.supabase.co",
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdsZXJjbmZmamJtZXRieXN0bndpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA3NjgwNDQsImV4cCI6MjA2NjM0NDA0NH0.Z9JvWS5zNp8rqyAVkSEIiVpB63gxM5g8e8bL6u6C64w"
-    );
+  <script type="module">
+    import supabase from './supabaseClient.js';
 
     const params = new URLSearchParams(window.location.search);
     const pseudo = params.get('pseudo');
@@ -100,6 +97,9 @@
 
       document.getElementById('status').textContent = `Liste créée avec l'id ${listeData.id}`;
     }
+
+    // Make the create handler accessible to the inline button
+    window.creerListe = creerListe;
   </script>
 </body>
 </html>

--- a/edit_liste.html
+++ b/edit_liste.html
@@ -66,11 +66,8 @@
     <button onclick="addTask()">Ajouter</button>
   </div>
 
-  <script>
-    const supabase = window.supabase.createClient(
-      "https://glercnffjbmetbystnwi.supabase.co",
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdsZXJjbmZmamJtZXRieXN0bndpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA3NjgwNDQsImV4cCI6MjA2NjM0NDA0NH0.Z9JvWS5zNp8rqyAVkSEIiVpB63gxM5g8e8bL6u6C64w"
-    );
+  <script type="module">
+    import supabase from './supabaseClient.js';
 
     const params = new URLSearchParams(window.location.search);
     const listeId = params.get('listeId');
@@ -170,6 +167,9 @@
       document.getElementById('newTask').value = '';
       loadData();
     }
+
+    // Allow the inline button to call addTask
+    window.addTask = addTask;
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -84,11 +84,8 @@
   <div id="listeGroup"></div>
   <div id="objectifs"></div>
 
-  <script>
-    const supabase = window.supabase.createClient(
-      "https://glercnffjbmetbystnwi.supabase.co",
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdsZXJjbmZmamJtZXRieXN0bndpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA3NjgwNDQsImV4cCI6MjA2NjM0NDA0NH0.Z9JvWS5zNp8rqyAVkSEIiVpB63gxM5g8e8bL6u6C64w"
-    );
+  <script type="module">
+    import supabase from './supabaseClient.js';
 
     let currentUser = null;
     let currentListe = null;
@@ -139,6 +136,9 @@
       createLink.style.marginTop = "1rem";
       listeGroup.appendChild(createLink);
     }
+
+    // Expose the search function for the inline button handler
+    window.rechercherListes = rechercherListes;
 
     async function loadTaches(listeId) {
       currentListe = listeId;

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,0 +1,5 @@
+const supabase = window.supabase.createClient(
+  "https://glercnffjbmetbystnwi.supabase.co",
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdsZXJjbmZmamJtZXRieXN0bndpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA3NjgwNDQsImV4cCI6MjA2NjM0NDA0NH0.Z9JvWS5zNp8rqyAVkSEIiVpB63gxM5g8e8bL6u6C64w"
+);
+export default supabase;


### PR DESCRIPTION
## Summary
- add `supabaseClient.js` exporting a configured Supabase client
- update HTML pages to import this module instead of duplicating credentials
- expose button handlers globally for module scripts
- add placeholder `favicon.ico`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bb5f1bfd88327ba938a72a929ae3d