### PR TITLE
Add list naming and tier editing

### DIFF
--- a/create_liste.html
+++ b/create_liste.html
@@ -44,11 +44,26 @@
     button:hover {
       background: #0055ff;
     }
+    .palier-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .palier-row input[type="text"] {
+      flex-grow: 1;
+    }
   </style>
 </head>
 <body>
   <h1>Créer une liste</h1>
   <div class="card">
+    <label for="nomListe">Nom de la liste</label>
+    <input type="text" id="nomListe" placeholder="Ma super liste" />
+
+    <h2>Paliers</h2>
+    <div id="paliers"></div>
+    <button type="button" onclick="ajouterPalier()">Ajouter un palier</button>
+
     <button onclick="creerListe()">Créer</button>
     <p id="status"></p>
   </div>
@@ -64,6 +79,34 @@
 
     }
 
+    const paliersDiv = document.getElementById('paliers');
+
+    function ajouterPalier(nom = '', ordre = '') {
+      const row = document.createElement('div');
+      row.className = 'palier-row';
+      const inputNom = document.createElement('input');
+      inputNom.type = 'text';
+      inputNom.placeholder = 'Nom du palier';
+      inputNom.value = nom;
+      inputNom.className = 'palier-nom';
+      const inputOrdre = document.createElement('input');
+      inputOrdre.type = 'number';
+      inputOrdre.placeholder = 'Ordre';
+      inputOrdre.value = ordre;
+      inputOrdre.className = 'palier-ordre';
+      const del = document.createElement('button');
+      del.type = 'button';
+      del.textContent = 'X';
+      del.onclick = () => row.remove();
+      row.appendChild(inputNom);
+      row.appendChild(inputOrdre);
+      row.appendChild(del);
+      paliersDiv.appendChild(row);
+    }
+
+    // ajouter une ligne par defaut
+    ajouterPalier('Général', 1);
+
     async function creerListe() {
       if (!pseudo) return;
 
@@ -78,9 +121,11 @@
         return;
       }
 
+      const nomListe = document.getElementById('nomListe').value.trim();
+
       const { data: listeData, error: err2 } = await supabase
         .from('listes')
-        .insert([{ user_id: userData.id }])
+        .insert([{ user_id: userData.id, nom: nomListe || null }])
         .select()
         .single();
 
@@ -89,17 +134,26 @@
         return;
       }
 
-      await supabase.from('paliers').insert({
+      const palierRows = document.querySelectorAll('#paliers .palier-row');
+      const paliers = Array.from(palierRows).map(r => ({
+        nom: r.querySelector('.palier-nom').value.trim() || 'Palier',
+        ordre: parseInt(r.querySelector('.palier-ordre').value, 10) || 1
+      }));
+
+      const inserts = paliers.length ? paliers.map(p => ({
         id_liste: listeData.id,
-        ordre: 1,
-        nom: 'Général'
-      });
+        nom: p.nom,
+        ordre: p.ordre
+      })) : [{ id_liste: listeData.id, nom: 'Général', ordre: 1 }];
+
+      await supabase.from('paliers').insert(inserts);
 
       document.getElementById('status').textContent = `Liste créée avec l'id ${listeData.id}`;
     }
 
-    // Make the create handler accessible to the inline button
+    // Make functions accessible to inline buttons
     window.creerListe = creerListe;
+    window.ajouterPalier = ajouterPalier;
   </script>
 </body>
 </html>

--- a/edit_liste.html
+++ b/edit_liste.html
@@ -54,10 +54,33 @@
       background: #ff0044;
       margin-left: 0.5rem;
     }
+    .palier-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .palier-row input[type="text"] {
+      flex-grow: 1;
+    }
   </style>
 </head>
 <body>
   <h1>Modifier une liste</h1>
+
+  <div class="card">
+    <h2>Nom de la liste</h2>
+    <input type="text" id="nomListe" />
+  </div>
+
+  <div class="card">
+    <h2>Paliers</h2>
+    <div id="palierList"></div>
+    <button type="button" onclick="ajouterPalier()">Ajouter un palier</button>
+  </div>
+
+  <button onclick="sauverListe()">Sauvegarder</button>
+
   <div id="tasks"></div>
   <div class="card">
     <h2>Ajouter une tâche</h2>
@@ -77,12 +100,47 @@
       loadData();
     }
 
+    const palierContainer = document.getElementById('palierList');
+
+    function ajouterPalier(nom = '', ordre = '', id = null) {
+      const row = document.createElement('div');
+      row.className = 'palier-row';
+      if (id) row.dataset.id = id;
+      const inputNom = document.createElement('input');
+      inputNom.type = 'text';
+      inputNom.placeholder = 'Nom du palier';
+      inputNom.value = nom;
+      inputNom.className = 'palier-nom';
+      const inputOrdre = document.createElement('input');
+      inputOrdre.type = 'number';
+      inputOrdre.placeholder = 'Ordre';
+      inputOrdre.value = ordre;
+      inputOrdre.className = 'palier-ordre';
+      const del = document.createElement('button');
+      del.type = 'button';
+      del.textContent = 'X';
+      del.onclick = () => row.remove();
+      row.appendChild(inputNom);
+      row.appendChild(inputOrdre);
+      row.appendChild(del);
+      palierContainer.appendChild(row);
+    }
     async function loadData() {
+      const { data: liste } = await supabase
+        .from('listes')
+        .select('nom')
+        .eq('id', listeId)
+        .single();
+      document.getElementById('nomListe').value = liste?.nom || '';
+
       const { data: paliers } = await supabase
         .from('paliers')
         .select('*')
         .eq('id_liste', listeId)
         .order('ordre', { ascending: true });
+
+      palierContainer.innerHTML = '';
+      paliers.forEach(p => ajouterPalier(p.nom, p.ordre, p.id));
 
       const palierSelect = document.getElementById('palierSelect');
       palierSelect.innerHTML = '';
@@ -168,8 +226,32 @@
       loadData();
     }
 
+    async function sauverListe() {
+      const nom = document.getElementById('nomListe').value.trim();
+      await supabase.from('listes').update({ nom }).eq('id', listeId);
+
+      const rows = document.querySelectorAll('#palierList .palier-row');
+      for (const row of rows) {
+        const id = row.dataset.id;
+        const nomP = row.querySelector('.palier-nom').value.trim() || 'Palier';
+        const ordre = parseInt(row.querySelector('.palier-ordre').value, 10) || 1;
+        if (id) {
+          await supabase.from('paliers').update({ nom: nomP, ordre }).eq('id', id);
+        } else {
+          await supabase.from('paliers').insert({
+            id_liste: listeId,
+            nom: nomP,
+            ordre
+          });
+        }
+      }
+      loadData();
+    }
+
     // Allow the inline button to call addTask
     window.addTask = addTask;
+    window.ajouterPalier = ajouterPalier;
+    window.sauverListe = sauverListe;
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
 
       const { data: listes } = await supabase
         .from("listes")
-        .select("id")
+        .select("id, nom")
         .eq("user_id", currentUser);
 
       const listeGroup = document.getElementById("listeGroup");
@@ -116,7 +116,7 @@
         const wrapper = document.createElement("div");
         const btn = document.createElement("button");
         btn.className = "liste-btn";
-        btn.textContent = `Liste #${liste.id}`;
+        btn.textContent = liste.nom ? liste.nom : `Liste #${liste.id}`;
         btn.onclick = () => loadTaches(liste.id);
         const edit = document.createElement("button");
         edit.className = "edit-btn";


### PR DESCRIPTION
## Summary
- allow specifying list name and tiers during creation
- enable editing list name and tiers
- show list names on the homepage

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685bbe9a786083279913884ce8ee7614